### PR TITLE
Fix linker error on Ubuntu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ OBJECTS= $(RCLIENT:.cpp=.o)
 all: $(EXECUTABLE)
 
 $(EXECUTABLE):  $(OBJECTS) $(DEMO)
-	$(CXX) $(LDFLAGS) $(DEMO) $(OBJECTS) -o $@
+	$(CXX) $(DEMO) $(OBJECTS) $(LDFLAGS) -o $@
 
 .PHONY : clean
 clean:


### PR DESCRIPTION
On Ubuntu, the gcc command line wants the -l library flag to come after the .o files with the missing symbols that the named library can supply.  RHEL6/7 apparently accepts the -l arguments either before or after the .o filenames.